### PR TITLE
Remove use of deprecated macros in documentation

### DIFF
--- a/doc/ratio.qbk
+++ b/doc/ratio.qbk
@@ -697,7 +697,7 @@ When __BOOST_RATIO_VERSION is 2 __BOOST_RATIO_DONT_PROVIDE_DEPRECATED_FEATURES_S
 [endsect]
 [section:assert Static Assert]
 
-When BOOST_NO_STATIC_ASSERT is defined, the user can select the way static assertions are reported. Define
+When BOOST_NO_CXX11_STATIC_ASSERT is defined, the user can select the way static assertions are reported. Define
 
 * __BOOST_RATIO_USES_STATIC_ASSERT to use Boost.StaticAssert.
 * __BOOST_RATIO_USES_MPL_ASSERT to use [*Boost.MPL] static assertions.


### PR DESCRIPTION
The documentation talks about the deprecated macro `BOOST_NO_STATIC_ASSERT` but the code (correctly) uses `BOOST_NO_CXX11_STATIC_ASSERT` instead.

Update the docs to use the correct macro.