### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Ratio is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required( VERSION 3.5 )
+project( BoostRatio LANGUAGES CXX)
+option( BOOST_RATIO_INCLUDE_TESTS "Add boost ratio tests" OFF )
+
+add_library( boost_ratio INTERFACE )
+add_library( Boost::ratio ALIAS boost_ratio )
+
+target_include_directories( boost_ratio INTERFACE include )
+
+target_link_libraries( boost_ratio
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::integer
+        Boost::mpl
+        Boost::static_assert
+        Boost::type_traits
+
+#		NOTE: dependency on rational is only needed when
+#       BOOST_RATIO_EXTENSIONS is defined.
+#       Maybe consuming libraries that do so should add
+#       Boost::rational as a dependency themselves
+        Boost::rational
+)
+
+if( BOOST_RATIO_INCLUDE_TESTS )
+    enable_testing()
+    add_subdirectory( test )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,11 @@ target_link_libraries( boost_ratio
         Boost::static_assert
         Boost::type_traits
 
-#		NOTE: dependency on rational is only needed when
-#       BOOST_RATIO_EXTENSIONS is defined.
+# NOTE: As of Boost 1.70, the dependency on rational is only
+#       necessary, if BOOST_RATIO_EXTENSIONS is defined.
 #       Maybe consuming libraries that do so should add
-#       Boost::rational as a dependency themselves
+#       Boost::rational as a dependency themselves,
+#       instead of doing it here for everyone?
         Boost::rational
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Ratio is currently experimental at best
+#       and this file runs only a subset of the unit tests
+#       (in particular none of the fail tests)
+
+# list of tests that contain a main function
+set( exec_test_files ratio_ext_pass;ratio_io_pass;ratio_pass )
+
+file( GLOB_RECURSE test_files *_pass.cpp )
+foreach( file IN LISTS test_files )
+
+    get_filename_component( core_name ${file} NAME_WE )
+    set( test_name test_boost_ratio_${core_name} )
+
+    if( ${core_name} IN_LIST exec_test_files )
+        add_executable( ${test_name} ${file} )
+        add_test( NAME ${test_name} COMMAND ${test_name} )
+    else()
+        # most tests are compile only, so we just need to create a object file
+        # in order to see, if it compiles
+        add_library( ${test_name} OBJECT ${file})
+    endif()
+
+    target_link_libraries( ${test_name} PUBLIC
+        Boost::ratio
+    )
+
+endforeach()


### PR DESCRIPTION
This PR adds minimal cmake support to boost.ratio, which means:

- It is not meant to be used standalone, but as a sub project (i.e. via `add_subdirectory(<path-to-boost-ratio>)` )
- It excpects that the dependencies like `Boost::config` are similarly provided by other sub_projects or directly by the super project - it does not look for them by itself.
- It can only be used to compile and run the `*_pass` unit tests.

Basic test instructions (assuming cmake is already installed and this version of Boost.Ratio is cloned into its usual place inside the boost super-project (i.e. `<boost-root/libs/ratio>`):

- Make sure, recent versions (i.e. from develop) of all libraries Boost.Ratio depends on directly or indirectly are cloned into sibling folders (e.g. just make a recursive clone of the the boost super project)
- Add a cmake file like the folowing into the root folder of the boost super project: https://github.com/Mike-Devel/boost/blob/min_cmake/CMakeLists.txt
  It essentially just calls `add_subdirectory` on all `./libs/<library-name>` subfolders that have a CMakeLists.txt file, but excludes a few libraries (if present) that don't work well with the `add_subdirectory` workflow yet.

Then from a command line (e.g. from boost-root):

    - mkdir __build__
    - cd __build__
    - cmake -DBOOST_RATIO_INCLUDE_TESTS=On <path-to-boost-root>
    - cmake --build .
    - ctest .
