### PR TITLE
[CMake] Run cmake from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -313,6 +313,10 @@ script:
   - |-
     echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
   - ./b2 libs/ratio/test toolset=$TOOLSET
+  - mkdir __wsl__ && cd __wsl__
+  - cmake -DBOOST_RATIO_INCLUDE_TESTS=ON ../libs/ratio/test/test_cmake
+  - cmake --build .
+  - ctest .
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,3 +39,8 @@ build: off
 
 test_script:
   - b2 libs/ratio/test toolset=%TOOLSET%
+  - mkdir __wsl__
+  - cd __wsl__
+  - cmake -DBOOST_RATIO_INCLUDE_TESTS=ON ../libs/ratio/test/test_cmake
+  - cmake --build .
+  - ctest .

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach( file IN LISTS test_files )
         add_executable( ${test_name} ${file} )
         add_test( NAME ${test_name} COMMAND ${test_name} )
     else()
-        # most tests are compile only, so we just need to create a object file
+        # most tests are compile only, so we just need to create an object file
         # in order to see, if it compiles
         add_library( ${test_name} STATIC ${file})
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach( file IN LISTS test_files )
     else()
         # most tests are compile only, so we just need to create a object file
         # in order to see, if it compiles
-        add_library( ${test_name} OBJECT ${file})
+        add_library( ${test_name} STATIC ${file})
     endif()
 
     target_link_libraries( ${test_name} PUBLIC

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+# NOTE: Individual boost cmake files might require a higher cmake version
+
+project(boost LANGUAGES CXX)
+
+#=== options ===
+
+# Some libraries' cmake files don't work well with this cmake file, e.g. because
+# - they are generally not designed to support the add_subdirectory workflow at all
+# - they define targets with conflicting names (e.g. check)
+# - require some additional (internal or external) dependencies
+#
+# Those libraries can be excluded here
+set(BOOST_MAIN_IGNORE_LIBS callable_traits;hof;compute;gil;hana;yap;safe_numerics;beast CACHE STRING "List of libraries that will be excluded from cmake build")
+
+
+#~~~ options ~~~
+message(STATUS "[Boost] Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
+
+# cmake doesn't require autolinking and currently most cmake files don't produce
+# name mangled libraries anyway
+message(STATUS "[Boost] Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
+add_definitions(-DBOOST_ALL_NO_LIB)
+enable_testing()
+
+# Detect and process all CMakeLists files that reside in the root folder of a library
+file(GLOB boost_libs_with_cmake_files ../../../*/CMakeLists.txt)
+
+foreach(cmake_file IN LISTS boost_libs_with_cmake_files)
+
+    get_filename_component(dir ${cmake_file} DIRECTORY)
+    get_filename_component(lib_name ${dir} NAME)
+	message(${dir})
+    if(NOT lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS)
+        add_subdirectory(${dir} ${lib_name})
+    endif()
+
+endforeach()

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -15,27 +15,25 @@ project(boost LANGUAGES CXX)
 # - require some additional (internal or external) dependencies
 #
 # Those libraries can be excluded here
-set(BOOST_MAIN_IGNORE_LIBS callable_traits;hof;compute;gil;hana;yap;safe_numerics;beast CACHE STRING "List of libraries that will be excluded from cmake build")
+set(BOOST_RATIO_IGNORE_LIBS callable_traits;hof;compute;gil;hana;yap;safe_numerics;beast CACHE STRING "List of libraries that will be excluded from cmake build")
 
 
 #~~~ options ~~~
-message(STATUS "[Boost] Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
+message(STATUS "[Boost] Excluded libs (BOOST_RATIO_IGNORE_LIBS): ${BOOST_RATIO_IGNORE_LIBS}")
 
 # cmake doesn't require autolinking and currently most cmake files don't produce
 # name mangled libraries anyway
-message(STATUS "[Boost] Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
 add_definitions(-DBOOST_ALL_NO_LIB)
 enable_testing()
 
 # Detect and process all CMakeLists files that reside in the root folder of a library
-file(GLOB boost_libs_with_cmake_files ../../../*/CMakeLists.txt)
+file(GLOB boost_libs_with_cmake_files ../../../../libs/*/CMakeLists.txt)
 
 foreach(cmake_file IN LISTS boost_libs_with_cmake_files)
 
     get_filename_component(dir ${cmake_file} DIRECTORY)
     get_filename_component(lib_name ${dir} NAME)
-	message(${dir})
-    if(NOT lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS)
+    if(NOT lib_name IN_LIST BOOST_RATIO_IGNORE_LIBS)
         add_subdirectory(${dir} ${lib_name})
     endif()
 


### PR DESCRIPTION
This is my initial draft for running the cmake script on the CI servers.
The appveyor seems to be broken for reasons unrelated to cmake.

Explanation:
The file `test/test_cmake/CMakeLists.txt` will process all checked out libraries with a cmake file including ratio (in the ci scripts only the libraries that ratio depends on are checked out) just as the user would do. It ss essentiall a copy of the one proposed here: https://github.com/boostorg/boost/pull/193/files and once something like that is added to the superproject, this local copy can be removed.